### PR TITLE
Fix validator ordering and misc

### DIFF
--- a/eth/v1alpha1/attestation.proto
+++ b/eth/v1alpha1/attestation.proto
@@ -29,11 +29,10 @@ message Attestation {
   // the same vote and have been aggregated into this attestation.
   bytes aggregation_bits = 2;
 
+  // Custody bits is used for proof of custody game to ensure validator has
+  // legitimately downloaded and verified shard data.
   // Not used in phase 0.
-  // 
-  // TODO: Add custody bitfield information.
-  // bytes custody_bits = 3;
-  reserved 3;
+  bytes custody_bits = 3;
 
   // 96 byte BLS aggregate signature.
   bytes signature = 4;

--- a/eth/v1alpha1/attestation.proto
+++ b/eth/v1alpha1/attestation.proto
@@ -43,7 +43,7 @@ message AttestationData {
   // See: https://arxiv.org/pdf/1710.09437.pdf
 
   // 32 byte root of the LMD GHOST block vote.
-  bytes block_root = 1;
+  bytes beacon_block_root = 1;
 
   // the most recent justified checkpoint in the beacon state
   Checkpoint source = 2;

--- a/eth/v1alpha1/validator.proto
+++ b/eth/v1alpha1/validator.proto
@@ -142,25 +142,25 @@ message Validator {
     // 32 byte hash of the withdrawal destination public key.
     bytes withdrawal_credentials = 2;
 
+    // The validators current effective balance in gwei.
+    uint64 effective_balance = 3;
+
+    // Whether or not the validator has been slashed.
+    bool slashed = 4;
+
     // Epoch when the validator became eligible for activation. This field may
     // be zero if the validator was present in the Ethereum 2.0 genesis.
-    uint64 activation_eligibility_epoch = 3;
+    uint64 activation_eligibility_epoch = 5;
 
     // Epoch when the validator was activated. This field may be zero if the
     // validator was present in the Ethereum 2.0 genesis.
-    uint64 activation_epoch = 4;
+    uint64 activation_epoch = 6;
 
     // Epoch when the validator was exited. This field may be zero if the
     // validator has not exited.
-    uint64 exit_epoch = 5;
+    uint64 exit_epoch = 7;
 
     // Epoch when the validator is eligible to withdraw their funds. This field
     // may be zero if the validator has not exited.
-    uint64 withdrawable_epoch = 6;
-
-    // Whether or not the validator has been slashed.
-    bool slashed = 7;
-
-    // The validators current effective balance in gwei.
-    uint64 effective_balance = 8;
+    uint64 withdrawable_epoch = 8;
 }


### PR DESCRIPTION
Updated:
- Added `custody_bits` back
- Renamed `block_root` -> `beacon_block_root`
- Fixed ordering of `Validator`