### PR TITLE
GetAttestationData to return Attestation

### DIFF
--- a/eth/v1alpha1/validator.proto
+++ b/eth/v1alpha1/validator.proto
@@ -72,9 +72,9 @@ service BeaconNodeValidator {
 
     // Retrieves the latest valid attestation data to be attested on the beacon chain.
     //
-    // The server returns the latest valid attestation data which represents the correct vote
+    // The server returns the latest valid attestation which represents the correct vote
     // for the head of the beacon chain,
-    rpc GetAttestationData(AttestationDataRequest) returns (AttestationData) {
+    rpc GetAttestationData(AttestationDataRequest) returns (Attestation) {
         option (google.api.http) = {
             get: "/eth/v1alpha1/validator/attestation"
         };


### PR DESCRIPTION
After chatting with Paul and Danny. We all decided returning `Attestation` is better here. 
This enables the validator to just add their signature to the aggregate, it allows beacon node to send pre-aggregated attestation (one with some aggregation bits set to true), validators don't have to worry on BLS specifics on sending empty signature and having to add on top of it