### PR TITLE
Modify ListAttestationsRequest Query Filters

### DIFF
--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -147,23 +147,29 @@ message ListAttestationsRequest {
 
     oneof query_filter {
         // Filter attestations by a specific block root.
-        bytes block_root = 1;
+        bytes head_block_root = 1;
 
-        // Filter attestations by slot number.
-        uint64 slot = 2;
+        // Filter attestations by source epoch.
+        uint64 source_epoch = 2;
 
-        // Filter attestations by epoch number.
-        uint64 epoch = 3;
+        // Filter attestations by target root.
+        bytes source_root = 3;
+
+        // Filter attestations by target epoch.
+        uint64 target_epoch = 4;
+
+        // Filter attestations by target root.
+        bytes target_root = 5;
     }
 
     // The maximum number of Attestations to return in the response.
     // This field is optional.
-    int32 page_size = 4;
+    int32 page_size = 6;
 
     // A pagination token returned from a previous call to `ListAttestations`
     // that indicates where this listing should continue from.
     // This field is optional.
-    string page_token = 5;
+    string page_token = 7;
 }
 
 message ListAttestationsResponse {


### PR DESCRIPTION
We have identified the current query filters contained in the `ListAttestationsRequest` is not very useful. Instead, we want to be able to filter by source root/epoch, target root/epoch, and head block root. This PR changes the query filters to those values.