### PR TITLE
Amend Participation to Use a One Of Query Filter

### DIFF
--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -264,7 +264,7 @@ message GetValidatorBalancesRequest {
 
     // Validator 48 byte BLS public keys to filter validators for the given
     // epoch.
-    repeated bytes public_keys = 3 [(gogoproto.moretags) = "ssz-size:\"?,48\""];
+    repeated bytes public_keys = 3;
         
     // Validator indices to filter validators for the given epoch.
     repeated uint64 indices = 4;

--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -254,15 +254,20 @@ message ChainHead {
 }
 
 message GetValidatorBalancesRequest {
-    // Retrieve validator balance at the given epoch.
-    uint64 epoch = 1;
+    oneof query_filter {
+        // Optional criteria to retrieve balances at a specific epoch.
+        uint64 epoch = 1;
+
+        // Optional criteria to retrieve the genesis list of balances.
+        bool genesis = 2;
+    }
 
     // Validator 48 byte BLS public keys to filter validators for the given
     // epoch.
-    repeated bytes public_keys = 2;
+    repeated bytes public_keys = 3 [(gogoproto.moretags) = "ssz-size:\"?,48\""];
         
     // Validator indices to filter validators for the given epoch.
-    repeated uint64 indices = 3;
+    repeated uint64 indices = 4;
 }
 
 message ValidatorBalances {
@@ -417,22 +422,15 @@ message GetValidatorParticipationRequest {
     uint64 epoch = 1;
 }
 
-message ValidatorParticipation {
+message ValidatorParticipationResponse {
     // Epoch which this message is applicable.
     uint64 epoch = 1;
 
     // Whether or not epoch has been finalized.
     bool finalized = 2;
 
-    // Percentage of validator participation in the given epoch. This field
-    // contains a value between 0 and 1.
-    float global_participation_rate = 3;
-
-    // The total amount of ether, in gwei, that has been used in voting.
-    uint64 voted_ether = 4;
-
-    // The total amount of ether, in gwei, that is eligible for voting.
-    uint64 eligible_ether = 5;   
+    // The actual validator participation metrics.
+    ValidatorParticipation participation = 3;
 }
 
 message AttestationPoolResponse {

--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -418,8 +418,13 @@ message ValidatorAssignments {
 }
 
 message GetValidatorParticipationRequest {
-    // Epoch to request participation information.
-    uint64 epoch = 1;
+    oneof query_filter {
+        // Epoch to request participation information.
+        uint64 epoch = 1;
+
+        // Whether or not to query for the genesis information.
+        bool genesis = 2;
+    }
 }
 
 message ValidatorParticipationResponse {

--- a/eth/v1alpha1/validator.proto
+++ b/eth/v1alpha1/validator.proto
@@ -164,3 +164,17 @@ message Validator {
     // may be zero if the validator has not exited.
     uint64 withdrawable_epoch = 8;
 }
+
+// ValidatorParticipation stores participation metrics during a given epoch.
+message ValidatorParticipation {
+    // Percentage of validator participation in the given epoch. This field
+    // contains a value between 0 and 1.
+    float global_participation_rate = 1;
+
+    // The total amount of ether, in gwei, that has been used in voting.
+    uint64 voted_ether = 2;
+
+    // The total amount of ether, in gwei, that is eligible for voting.
+    uint64 eligible_ether = 3;   
+}
+


### PR DESCRIPTION
We amend the validator participation request to:

```
message GetValidatorParticipationRequest {
    oneof query_filter {
        // Epoch to request participation information.
        uint64 epoch = 1;

        // Whether or not to query for the genesis information.
        bool genesis = 2;
    }
}
```
This makes it so users have to specify one criteria or the other, preventing tricky situations such as requests that have genesis = true and epoch = 100.