### PR TITLE
Add Query Filter to Active Set Changes Request

### DIFF
--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -324,7 +324,13 @@ message Validators {
 }
 
 message GetValidatorActiveSetChangesRequest {
-    uint64 epoch = 1;
+    oneof query_filter {
+        // Optional criteria to retrieve balances at a specific epoch.
+        uint64 epoch = 1;
+
+        // Optional criteria to retrieve the genesis list of balances.
+        bool genesis = 2;
+    }
 }
 
 message ActiveSetChanges {


### PR DESCRIPTION
This PR adds a oneof query filter by epoch or genesis to the validator active set changes request message