### PR TITLE
Update grpc-gateway to use camel case

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,10 +28,13 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
 
+# TODO: Update to master commit after https://github.com/grpc-ecosystem/grpc-gateway/pull/1077 merges.
 go_repository(
     name = "grpc_ecosystem_grpc_gateway",
-    commit = "740ef2ee80c49ed4a272e8c3b54ebf352109f572",
+    commit = "70fc48afe5b7473aa1e6796e5013ae63dce74043",
     importpath = "github.com/grpc-ecosystem/grpc-gateway",
+    remote = "https://github.com/prestonvanloon/grpc-gateway",
+    vcs = "git",
 )
 
 go_repository(

--- a/eth/v1alpha1/BUILD.bazel
+++ b/eth/v1alpha1/BUILD.bazel
@@ -52,8 +52,7 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "@grpc_ecosystem_grpc_gateway//protoc-gen-swagger/options:options_go_proto",
-
-                "@go_googleapis//google/api:annotations_go_proto",
+        "@go_googleapis//google/api:annotations_go_proto",
     ],
 )
 
@@ -74,4 +73,5 @@ protoc_gen_swagger(
     proto = ":proto",
     visibility = ["//visibility:public"],
     single_output = True,
+    json_names_for_fields = True,
 )


### PR DESCRIPTION
This makes a nicer UI for swagger at https://api.prylabs.network (already deployed this branch).