### PR TITLE
Update Validator Assignments for Compatibility

### DIFF
--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -428,7 +428,7 @@ message ValidatorAssignments {
         // duty as an attester.
         uint64 proposer_slot = 4;
 
-        // 48 byte BLS public key .
+        // 48 byte BLS public key.
         bytes public_key = 5;
     }
 

--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -420,16 +420,15 @@ message ValidatorAssignments {
         // Committee index represents the committee of validator that's in.
         uint64 committee_index = 2;
 
-        // Beacon chain slot in which the validator must perform its assigned 
-        // duty.
-        uint64 slot = 3;
+        // Beacon chain slot in which the validator must perform its assigned
+        // duty as an attester.
+        uint64 attester_slot = 3;
 
-        // Whether or not the validator is assigned to propose at this slot. If
-        // This field is false, then they are only to attest during the
-        // assignment time.
-        bool proposer = 4;
+        // Beacon chain slot in which the validator must perform its assigned
+        // duty as an attester.
+        uint64 proposer_slot = 4;
 
-        // 48 byte BLS public key 
+        // 48 byte BLS public key .
         bytes public_key = 5;
     }
 


### PR DESCRIPTION
The structure of validator assignments in the protobuf response changed in https://github.com/prysmaticlabs/prysm/pull/3962. This PR updates this repo to match latest Prysm compatibility.