### PR TITLE
Standardize Naming for List Style Services

### DIFF
--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -96,7 +96,7 @@ service BeaconChain {
     // Retrieve the current validator registry.
     //
     // The request may include an optional historical epoch to retrieve a 
-    // specific validator set in time. Can also filter to retrieve active validators.
+    // specific validator set in time.
     rpc ListValidators(ListValidatorsRequest) returns (Validators) {
         option (google.api.http) = {
             get: "/eth/v1alpha1/validators"

--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -87,17 +87,17 @@ service BeaconChain {
 
     // Retrieve validator balances for a given set of public keys at a specific 
     // epoch in time.
-    rpc ListValidatorBalances(GetValidatorBalancesRequest) returns (ValidatorBalances) { 
+    rpc ListValidatorBalances(ListValidatorBalancesRequest) returns (ValidatorBalances) {
         option (google.api.http) = {
             get: "/eth/v1alpha1/validators/balances"
         };
     }
 
-    // Retrieve the current list of active validators. 
+    // Retrieve the current validator registry.
     //
     // The request may include an optional historical epoch to retrieve a 
-    // specific validator set in time.
-    rpc GetValidators(GetValidatorsRequest) returns (Validators) {
+    // specific validator set in time. Can also filter to retrieve active validators.
+    rpc ListValidators(ListValidatorsRequest) returns (Validators) {
         option (google.api.http) = {
             get: "/eth/v1alpha1/validators"
         };
@@ -273,7 +273,7 @@ message ChainHead {
     bytes previous_justified_block_root = 12;
 }
 
-message GetValidatorBalancesRequest {
+message ListValidatorBalancesRequest {
     oneof query_filter {
         // Optional criteria to retrieve balances at a specific epoch.
         uint64 epoch = 1;
@@ -324,7 +324,7 @@ message ValidatorBalances {
     int32 total_size = 4;
 }
 
-message GetValidatorsRequest {
+message ListValidatorsRequest {
     oneof query_filter {
         // Optional criteria to retrieve validators at a specific epoch. 
         // Omitting this field or setting it to zero will retrieve a response


### PR DESCRIPTION
Currently we have various services named such as `ListValidatorBalances` but the request types are called `GetValidatorBalancesRequest`. We will opt for the following convention:

- Fetching a single item: prefix the request/service with `Get`
- Fetching a list of items (usually paginated): prefix the request/service with `List`