### PR TITLE
Ensure Parity Between EthAPIs and Prysm

### DIFF
--- a/eth/v1alpha1/beacon_block.proto
+++ b/eth/v1alpha1/beacon_block.proto
@@ -132,30 +132,6 @@ message VoluntaryExit {
     bytes signature = 3;
 }
 
-// A beacon chain transfer is a ETH currency transfer between two validators.
-message Transfer {
-    // Validator index of the sender.
-    uint64 sender_index = 1;
-
-    // Validator index of the recipient. 
-    uint64 recipient_index = 2;
-
-    // Amount in gwei sent to the recipient.
-    uint64 amount = 3; 
-
-    // Fee in gwei for the block proposer to include this transfer.
-    uint64 fee = 4;
-
-    // Slot at which transfer must be processed. This is used for replay protection.
-    uint64 slot = 5;
-
-    // 48 byte sender's withdrawal public key.
-    bytes sender_withdrawal_public_key = 6;
-
-    // 96 byte signature from the sender's withdrawal key.
-    bytes signature = 7;
-}
-
 // Eth1Data represents references to the Ethereum 1.x deposit contract.
 message Eth1Data {
     // The 32 byte deposit tree root for the last deposit included in this

--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -96,7 +96,7 @@ service BeaconChain {
     // Retrieve the current validator registry.
     //
     // The request may include an optional historical epoch to retrieve a 
-    // specific validator set in time. Can also filter to retrieve active validators.
+    // specific validator set in time.
     rpc ListValidators(ListValidatorsRequest) returns (Validators) {
         option (google.api.http) = {
             get: "/eth/v1alpha1/validators"

--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -87,17 +87,17 @@ service BeaconChain {
 
     // Retrieve validator balances for a given set of public keys at a specific 
     // epoch in time.
-    rpc ListValidatorBalances(GetValidatorBalancesRequest) returns (ValidatorBalances) { 
+    rpc ListValidatorBalances(ListValidatorBalancesRequest) returns (ValidatorBalances) {
         option (google.api.http) = {
             get: "/eth/v1alpha1/validators/balances"
         };
     }
 
-    // Retrieve the current list of active validators. 
+    // Retrieve the current validator registry.
     //
     // The request may include an optional historical epoch to retrieve a 
-    // specific validator set in time.
-    rpc GetValidators(GetValidatorsRequest) returns (Validators) {
+    // specific validator set in time. Can also filter to retrieve active validators.
+    rpc ListValidators(ListValidatorsRequest) returns (Validators) {
         option (google.api.http) = {
             get: "/eth/v1alpha1/validators"
         };
@@ -273,7 +273,7 @@ message ChainHead {
     bytes previous_justified_block_root = 12;
 }
 
-message GetValidatorBalancesRequest {
+message ListValidatorBalancesRequest {
     oneof query_filter {
         // Optional criteria to retrieve balances at a specific epoch.
         uint64 epoch = 1;
@@ -324,7 +324,7 @@ message ValidatorBalances {
     int32 total_size = 4;
 }
 
-message GetValidatorsRequest {
+message ListValidatorsRequest {
     oneof query_filter {
         // Optional criteria to retrieve validators at a specific epoch. 
         // Omitting this field or setting it to zero will retrieve a response

--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -313,7 +313,7 @@ message BeaconCommittees {
     // The epoch for which the committees in the response belong to.
     uint64 epoch = 1;
 
-    // A list of committees of validators for given  epoch.
+    // A list of committees of validators for given epoch.
     repeated CommitteeItem committees = 2;
 
     // The number of active validators at the given epoch.

--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -85,6 +85,16 @@ service BeaconChain {
         };
     }
 
+    // Retrieve the beacon chain committees for a given epoch.
+    //
+    // If no filter criteria is specified, the response returns
+    // all beacon committees for the current epoch. The results are paginated by default.
+    rpc ListBeaconCommittees(ListCommitteesRequest) returns (BeaconCommittees) {
+        option (google.api.http) = {
+            get: "/eth/v1alpha1/beacon/committees"
+        };
+    }
+
     // Retrieve validator balances for a given set of public keys at a specific 
     // epoch in time.
     rpc ListValidatorBalances(ListValidatorBalancesRequest) returns (ValidatorBalances) {
@@ -272,6 +282,51 @@ message ChainHead {
     // Previous 32 byte justified block root.
     bytes previous_justified_block_root = 12;
 }
+
+message ListCommitteesRequest {
+    oneof query_filter {
+        // Optional criteria to retrieve data at a specific epoch.
+        uint64 epoch = 1;
+
+        // Optional criteria to retrieve genesis data.
+        bool genesis = 2;
+    }
+
+    // The maximum number of Validators to return in the response.
+    // This field is optional.
+    int32 page_size = 3;
+
+    // A pagination token returned from a previous call to `GetValidators`
+    // that indicates where this listing should continue from.
+    // This field is optional.
+    string page_token = 4;
+}
+
+message BeaconCommittees {
+    message CommitteeItem {
+        // A committee of validator indices that need to attest to beacon blocks.
+        repeated uint64 committee = 1;
+
+        // The slot at which the committee is assigned to.
+        uint64 slot = 2;
+    }
+    // The epoch for which the committees in the response belong to.
+    uint64 epoch = 1;
+
+    // A list of committees of validators for given  epoch.
+    repeated CommitteeItem committees = 2;
+
+    // The number of active validators at the given epoch.
+    uint64 active_validator_count = 3;
+
+    // A pagination token returned from a previous call
+    // that indicates from where the listing should continue.
+    string next_page_token = 4;
+
+    // Total count of committees matching the request filter.
+    int32 total_size = 5;
+}
+
 
 message ListValidatorBalancesRequest {
     oneof query_filter {


### PR DESCRIPTION
This PR includes `ListBeaconCommittees` as a service and removes the `Transfer` type from EthereumAPIs to match latest standards in Prysm