### PR TITLE
Add Active Filter to ListValidatorsRequest

### DIFF
--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -389,14 +389,17 @@ message ListValidatorsRequest {
         bool genesis = 2;
     }
 
+    // Specify whether or not you want to retrieve only active validators.
+    bool active = 3;
+
     // The maximum number of Validators to return in the response.
     // This field is optional.
-    int32 page_size = 3;
+    int32 page_size = 4;
 
     // A pagination token returned from a previous call to `GetValidators`
     // that indicates where this listing should continue from.
     // This field is optional.
-    string page_token = 4;
+    string page_token = 5;
 }
 
 message Validators {


### PR DESCRIPTION
This PR adds an optional field `active` to the LIstValidatorsRequest to retrieve active validators only