### PR TITLE
stream signed blocks instead of blocks

### DIFF
--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -85,9 +85,9 @@ service BeaconChain {
         };
     }
 
-    // Server-side stream of all blocks as they are received by
-    // the beacon chain node. 
-    rpc StreamBlocks(google.protobuf.Empty) returns (stream BeaconBlock) {
+    // Server-side stream of all signed blocks as they are received by
+    // the beacon chain node.
+    rpc StreamBlocks(google.protobuf.Empty) returns (stream SignedBeaconBlock) {
         option (google.api.http) = {
             get: "/eth/v1alpha1/beacon/blocks/stream"
         };


### PR DESCRIPTION
slasher need the signature to compose the proposer slashing proof therefore signed block or signed block header should be streamed