### PR TITLE
Include Go SSZ Tags By Default

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,3 +51,15 @@ go_repository(
     commit = "51d6538a90f86fe93ac480b35f37b2be17fef232",
     importpath = "gopkg.in/yaml.v2",
 )
+
+go_repository(
+    name = "com_github_ferranbt_fastssz",
+    commit = "06015a5d84f9e4eefe2c21377ca678fa8f1a1b09",
+    importpath = "github.com/ferranbt/fastssz",
+)
+
+go_repository(
+    name = "com_github_prysmaticlabs_go_bitfield",
+    commit = "62c2aee7166951c456888f92237aee4303ba1b9d",
+    importpath = "github.com/prysmaticlabs/go-bitfield",
+)

--- a/eth/v1alpha1/BUILD.bazel
+++ b/eth/v1alpha1/BUILD.bazel
@@ -3,7 +3,7 @@
 ##############################################################################
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-# load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
 
 ##############################################################################
 # Go
@@ -43,11 +43,14 @@ proto_library(
 # Java
 ##############################################################################
 
-# java_proto_library(
-#     name = "java_proto",
-#     deps = [":proto"],
-# )
+java_proto_library(
+    name = "java_proto",
+    deps = [":proto"],
+)
 
+##############################################################################
+# Go
+##############################################################################
 ssz_gen_marshal(
     name = "ssz_generated_files",
     go_proto = ":go_proto",

--- a/eth/v1alpha1/BUILD.bazel
+++ b/eth/v1alpha1/BUILD.bazel
@@ -3,8 +3,7 @@
 ##############################################################################
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_java//java:defs.bzl", "java_proto_library")
-load("@prysm//tools:ssz.bzl", "SSZ_DEPS", "ssz_gen_marshal")
+# load("@rules_java//java:defs.bzl", "java_proto_library")
 
 ##############################################################################
 # Go
@@ -12,6 +11,7 @@ load("@prysm//tools:ssz.bzl", "SSZ_DEPS", "ssz_gen_marshal")
 # gazelle:ignore
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("//tools:ssz.bzl", "SSZ_DEPS", "ssz_gen_marshal")
 
 ##############################################################################
 # OpenAPI (Swagger) V2
@@ -26,6 +26,7 @@ proto_library(
         "beacon_chain.proto",
         "node.proto",
         "validator.proto",
+        ":generated_swagger_proto",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -42,22 +43,10 @@ proto_library(
 # Java
 ##############################################################################
 
-java_proto_library(
-    name = "java_proto",
-    deps = [":proto"],
-)
-
-go_proto_library(
-    name = "go_proto",
-    compilers = ["@prysm//:grpc_proto_compiler"],
-    importpath = "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1",
-    proto = ":proto",
-    visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
-        "@go_googleapis//google/api:annotations_go_proto",
-    ],
-)
+# java_proto_library(
+#     name = "java_proto",
+#     deps = [":proto"],
+# )
 
 ssz_gen_marshal(
     name = "ssz_generated_files",
@@ -76,21 +65,34 @@ ssz_gen_marshal(
 )
 
 go_proto_library(
+    name = "go_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogofast_grpc"],
+    importpath = "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1",
+    proto = ":proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@go_googleapis//google/api:annotations_go_proto",
+        "@grpc_ecosystem_grpc_gateway//protoc-gen-swagger/options:options_go_proto",
+        "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
+    ],
+)
+
+go_proto_library(
     name = "go_grpc_gateway_library",
     compilers = [
-        "@prysm//:grpc_nogogo_proto_compiler",
+        "@io_bazel_rules_go//proto:go_grpc",
         "@grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway:go_gen_grpc_gateway",
     ],
     importpath = "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1_gateway",
     proto = ":proto",
     visibility = ["//visibility:public"],
     deps = [
+        "@go_googleapis//google/api:annotations_go_proto",
+        "@grpc_ecosystem_grpc_gateway//protoc-gen-swagger/options:options_go_proto",
         "@com_github_gogo_protobuf//gogoproto:go_default_library",
         "@com_github_golang_protobuf//descriptor:go_default_library",
         "@com_github_golang_protobuf//ptypes/empty:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
-        "@go_googleapis//google/api:annotations_go_proto",
-        "@grpc_ecosystem_grpc_gateway//protoc-gen-swagger/options:options_go_proto",
     ],
 )
 

--- a/eth/v1alpha1/BUILD.bazel
+++ b/eth/v1alpha1/BUILD.bazel
@@ -4,6 +4,7 @@
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@prysm//tools:ssz.bzl", "SSZ_DEPS", "ssz_gen_marshal")
 
 ##############################################################################
 # Go
@@ -25,7 +26,6 @@ proto_library(
         "beacon_chain.proto",
         "node.proto",
         "validator.proto",
-        ":generated_swagger_proto",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -33,6 +33,7 @@ proto_library(
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:timestamp_proto",
         "@go_googleapis//google/api:annotations_proto",
+        "@gogo_special_proto//github.com/gogo/protobuf/gogoproto",
         "@grpc_ecosystem_grpc_gateway//protoc-gen-swagger/options:options_proto",
     ],
 )
@@ -48,11 +49,46 @@ java_proto_library(
 
 go_proto_library(
     name = "go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = ["@prysm//:grpc_proto_compiler"],
     importpath = "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1",
     proto = ":proto",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
+        "@go_googleapis//google/api:annotations_go_proto",
+    ],
+)
+
+ssz_gen_marshal(
+    name = "ssz_generated_files",
+    go_proto = ":go_proto",
+    objs = [
+        "Attestation",
+        "BeaconBlock",
+        "SignedBeaconBlock",
+        "Validator",
+        "BeaconBlockHeader",
+        "AttesterSlashing",
+        "VoluntaryExit",
+        "Deposit",
+        "ProposerSlashing",
+    ],
+)
+
+go_proto_library(
+    name = "go_grpc_gateway_library",
+    compilers = [
+        "@prysm//:grpc_nogogo_proto_compiler",
+        "@grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway:go_gen_grpc_gateway",
+    ],
+    importpath = "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1_gateway",
+    proto = ":proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_gogo_protobuf//gogoproto:go_default_library",
+        "@com_github_golang_protobuf//descriptor:go_default_library",
+        "@com_github_golang_protobuf//ptypes/empty:go_default_library",
+        "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@go_googleapis//google/api:annotations_go_proto",
         "@grpc_ecosystem_grpc_gateway//protoc-gen-swagger/options:options_go_proto",
     ],
@@ -60,9 +96,11 @@ go_proto_library(
 
 go_library(
     name = "go_default_library",
+    srcs = [":ssz_generated_files"],
     embed = [":go_proto"],
     importpath = "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1",
     visibility = ["//visibility:public"],
+    deps = SSZ_DEPS,
 )
 
 protoc_gen_swagger(

--- a/eth/v1alpha1/attestation.proto
+++ b/eth/v1alpha1/attestation.proto
@@ -15,6 +15,8 @@ syntax = "proto3";
 
 package ethereum.eth.v1alpha1;
 
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+
 option csharp_namespace = "Ethereum.Eth.v1alpha1";
 option go_package = "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1;eth";
 option java_multiple_files = true;
@@ -25,12 +27,12 @@ option php_namespace = "Ethereum\\Eth\\v1alpha1";
 message Attestation {
     // A bitfield representation of validator indices that have voted exactly
     // the same vote and have been aggregated into this attestation.
-    bytes aggregation_bits = 1;
+    bytes aggregation_bits = 1 [(gogoproto.moretags) = "ssz-max:\"2048\"", (gogoproto.casttype) = "github.com/prysmaticlabs/go-bitfield.Bitlist"];
 
     AttestationData data = 2;
 
     // 96 byte BLS aggregate signature.
-    bytes signature = 3;
+    bytes signature = 3 [(gogoproto.moretags) = "ssz-size:\"96\""];
 }
 
 message AggregateAttestationAndProof {
@@ -41,7 +43,7 @@ message AggregateAttestationAndProof {
     Attestation aggregate = 3;
 
     // 96 byte selection proof signed by the aggregator, which is the signature of the slot to aggregate.
-    bytes selection_proof = 2;
+    bytes selection_proof = 2 [(gogoproto.moretags) = "ssz-size:\"96\""];
 }
 
 message SignedAggregateAttestationAndProof {
@@ -49,7 +51,7 @@ message SignedAggregateAttestationAndProof {
     AggregateAttestationAndProof message = 1;
 
     // 96 byte BLS aggregate signature signed by the aggregator over the message.
-    bytes signature = 2;
+    bytes signature = 2 [(gogoproto.moretags) = "ssz-size:\"96\""];
 }
 
 message AttestationData {
@@ -63,7 +65,7 @@ message AttestationData {
     uint64 committee_index = 2;
 
     // 32 byte root of the LMD GHOST block vote.
-    bytes beacon_block_root = 3;
+    bytes beacon_block_root = 3 [(gogoproto.moretags) = "ssz-size:\"32\""];
 
     // The most recent justified checkpoint in the beacon state
     Checkpoint source = 4;
@@ -99,5 +101,5 @@ message Checkpoint {
     uint64 epoch = 1;
 
     // Block root of the checkpoint references.
-    bytes root = 2;
+    bytes root = 2 [(gogoproto.moretags) = "ssz-size:\"32\""];
 }

--- a/eth/v1alpha1/beacon_block.proto
+++ b/eth/v1alpha1/beacon_block.proto
@@ -15,6 +15,7 @@ syntax = "proto3";
 
 package ethereum.eth.v1alpha1;
 
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 import "eth/v1alpha1/attestation.proto";
 
 option csharp_namespace = "Ethereum.Eth.v1alpha1";
@@ -33,10 +34,10 @@ message BeaconBlock {
     uint64 proposer_index = 2;
 
     // 32 byte root of the parent block.
-    bytes parent_root = 3;
+    bytes parent_root = 3 [(gogoproto.moretags) = "ssz-size:\"32\""];
 
     // 32 byte root of the resulting state after processing this block.
-    bytes state_root = 4;
+    bytes state_root = 4 [(gogoproto.moretags) = "ssz-size:\"32\""];
 
     // The block body itself.
     BeaconBlockBody body = 5;
@@ -48,38 +49,38 @@ message SignedBeaconBlock {
     BeaconBlock block = 1;
 
     // 96 byte BLS signature from the validator that produced this block.
-    bytes signature = 2;
+    bytes signature = 2 [(gogoproto.moretags) = "ssz-size:\"96\""];
 }
 
 // The block body of an Ethereum 2.0 beacon block.
 message BeaconBlockBody {
     // The validators RANDAO reveal 96 byte value.
-    bytes randao_reveal = 1;
+    bytes randao_reveal = 1 [(gogoproto.moretags) = "ssz-size:\"96\""];
 
     // A reference to the Ethereum 1.x chain.
     Eth1Data eth1_data = 2;
 
     // 32 byte field of arbitrary data. This field may contain any data and
     // is not used for anything other than a fun message.
-    bytes graffiti = 3;
+    bytes graffiti = 3 [(gogoproto.moretags) = "ssz-size:\"32\""];
 
     // Block operations
     // Refer to spec constants at https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md#max-operations-per-block
 
     // At most MAX_PROPOSER_SLASHINGS.
-    repeated ProposerSlashing proposer_slashings = 4;
+    repeated ProposerSlashing proposer_slashings = 4 [(gogoproto.moretags) = "ssz-max:\"16\""];
 
     // At most MAX_ATTESTER_SLASHINGS.
-    repeated AttesterSlashing attester_slashings = 5;
+    repeated AttesterSlashing attester_slashings = 5 [(gogoproto.moretags) = "ssz-max:\"1\""];
 
     // At most MAX_ATTESTATIONS.
-    repeated Attestation attestations = 6;
+    repeated Attestation attestations = 6 [(gogoproto.moretags) = "ssz-max:\"128\""];
 
     // At most MAX_DEPOSITS.
-    repeated Deposit deposits = 7;
+    repeated Deposit deposits = 7 [(gogoproto.moretags) = "ssz-max:\"16\""];
 
     // At most MAX_VOLUNTARY_EXITS.
-    repeated SignedVoluntaryExit voluntary_exits = 8;
+    repeated SignedVoluntaryExit voluntary_exits = 8 [(gogoproto.moretags) = "ssz-max:\"16\""];
 }
 
 // Proposer slashings are proofs that a slashable offense has been committed by
@@ -106,20 +107,20 @@ message AttesterSlashing {
 message Deposit {
     message Data {
         // 48 byte BLS public key of the validator.
-        bytes public_key = 1;
+        bytes public_key = 1 [(gogoproto.moretags) = "ssz-size:\"48\" spec-name:\"pubkey\""];
 
         // A 32 byte hash of the withdrawal address public key.
-        bytes withdrawal_credentials = 2;
+        bytes withdrawal_credentials = 2 [(gogoproto.moretags) = "ssz-size:\"32\""];
 
         // Deposit amount in gwei.
         uint64 amount = 3;
 
         // 96 byte signature from the validators public key.
-        bytes signature = 4;
+        bytes signature = 4 [(gogoproto.moretags) = "ssz-size:\"96\""];
     }
 
     // 32 byte roots in the deposit tree branch.
-    repeated bytes proof = 1;
+    repeated bytes proof = 1 [(gogoproto.moretags) = "ssz-size:\"33,32\""];
 
     Data data = 2;
 }
@@ -141,14 +142,14 @@ message SignedVoluntaryExit {
     VoluntaryExit exit = 1;
 
     // Validator's 96 byte signature
-    bytes signature = 2;
+    bytes signature = 2 [(gogoproto.moretags) = "ssz-size:\"96\""];
 }
 
 // Eth1Data represents references to the Ethereum 1.x deposit contract.
 message Eth1Data {
     // The 32 byte deposit tree root for the last deposit included in this
     // block.
-    bytes deposit_root = 1;
+    bytes deposit_root = 1 [(gogoproto.moretags) = "ssz-size:\"32\""];
 
     // The total number of deposits included in the beacon chain since genesis
     // including the deposits in this block.
@@ -156,7 +157,7 @@ message Eth1Data {
 
     // The 32 byte block hash of the Ethereum 1.x block considered for deposit
     // inclusion.
-    bytes block_hash = 3;
+    bytes block_hash = 3 [(gogoproto.moretags) = "ssz-size:\"32\""];
 }
 
 // A beacon block header is essentially a beacon block with only a reference to
@@ -171,13 +172,13 @@ message BeaconBlockHeader {
     uint64 proposer_index = 2;
 
     // 32 byte merkle tree root of the parent ssz encoded block.
-    bytes parent_root = 3;
+    bytes parent_root = 3 [(gogoproto.moretags) = "ssz-size:\"32\""];
 
     // 32 byte merkle tree root of the resulting ssz encoded state after processing this block.
-    bytes state_root = 4;
+    bytes state_root = 4 [(gogoproto.moretags) = "ssz-size:\"32\""];
 
     // 32 byte merkle tree root of the ssz encoded block body.
-    bytes body_root = 5;
+    bytes body_root = 5 [(gogoproto.moretags) = "ssz-size:\"32\""];
 }
 
 message SignedBeaconBlockHeader {
@@ -185,14 +186,14 @@ message SignedBeaconBlockHeader {
     BeaconBlockHeader header = 1;
 
     // 96 byte BLS signature from the validator that produced this block header.
-    bytes signature = 2;
+    bytes signature = 2 [(gogoproto.moretags) = "ssz-size:\"96\""];
 }
 
 message IndexedAttestation {
-    repeated uint64 attesting_indices = 1;
+    repeated uint64 attesting_indices = 1 [(gogoproto.moretags) = "ssz-max:\"2048\""];
 
     AttestationData data = 2;
 
     // 96 bytes aggregate signature.
-    bytes signature = 3;
+    bytes signature = 3 [(gogoproto.moretags) = "ssz-size:\"96\""];
 }

--- a/eth/v1alpha1/beacon_chain.proto
+++ b/eth/v1alpha1/beacon_chain.proto
@@ -15,6 +15,7 @@ syntax = "proto3";
 
 package ethereum.eth.v1alpha1;
 
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/any.proto";
@@ -398,7 +399,7 @@ message ChainHead {
     uint64 head_epoch = 2;
 
     // 32 byte merkle tree root of the canonical head block in the beacon node.
-    bytes head_block_root = 3;
+    bytes head_block_root = 3 [(gogoproto.moretags) = "ssz-size:\"32\""];
 
     // Most recent slot that contains the finalized block.
     uint64 finalized_slot = 4;
@@ -407,7 +408,7 @@ message ChainHead {
     uint64 finalized_epoch = 5;
 
     // Most recent 32 byte finalized block root.
-    bytes finalized_block_root = 6;
+    bytes finalized_block_root = 6 [(gogoproto.moretags) = "ssz-size:\"32\""];
 
     // Most recent slot that contains the justified block.
     uint64 justified_slot = 7;
@@ -416,7 +417,7 @@ message ChainHead {
     uint64 justified_epoch = 8;
 
     // Most recent 32 byte justified block root.
-    bytes justified_block_root = 9;
+    bytes justified_block_root = 9 [(gogoproto.moretags) = "ssz-size:\"32\""];
 
     // Most recent slot that contains the previous justified block.
     uint64 previous_justified_slot = 10;
@@ -425,7 +426,7 @@ message ChainHead {
     uint64 previous_justified_epoch = 11;
 
     // Previous 32 byte justified block root.
-    bytes previous_justified_block_root = 12;
+    bytes previous_justified_block_root = 12 [(gogoproto.moretags) = "ssz-size:\"32\""];
 }
 
 message ListCommitteesRequest {
@@ -470,8 +471,7 @@ message ListValidatorBalancesRequest {
 
     // Validator 48 byte BLS public keys to filter validators for the given
     // epoch.
-    repeated bytes public_keys = 3;
-
+    repeated bytes public_keys = 3 [(gogoproto.moretags) = "ssz-size:\"?,48\""];
     // Validator indices to filter validators for the given epoch.
     repeated uint64 indices = 4;
 
@@ -491,7 +491,7 @@ message ValidatorBalances {
 
     message Balance {
         // Validator's 48 byte BLS public key.
-        bytes public_key = 1;
+        bytes public_key = 1 [(gogoproto.moretags) = "ssz-size:\"48\""];
 
         // Validator's index in the validator set.
         uint64 index = 2;
@@ -548,7 +548,7 @@ message GetValidatorRequest {
         uint64 index = 1;
 
         // 48 byte validator public key.
-        bytes public_key = 2;
+        bytes public_key = 2 [(gogoproto.moretags) = "ssz-size:\"48\""];
     }
 }
 
@@ -590,26 +590,25 @@ message ActiveSetChanges {
     uint64 epoch = 1;
 
     // 48 byte validator public keys that have been activated in the given epoch.
-    repeated bytes activated_public_keys = 2;
+    repeated bytes activated_public_keys = 2 [(gogoproto.moretags) = "ssz-size:\"?,48\""];
 
     // Indices of validators activated in the given epoch.
     repeated uint64 activated_indices = 3;
 
-    // 48 byte validator public keys that have been voluntarily exited in this
-    // epoch.
-    repeated bytes exited_public_keys = 4;
+    // 48 byte validator public keys that have been voluntarily exited in the given epoch.
+    repeated bytes exited_public_keys = 4 [(gogoproto.moretags) = "ssz-size:\"?,48\""];
 
     // Indices of validators exited in the given epoch.
     repeated uint64 exited_indices = 5;
 
-    // 48 byte validator public keys that have been slashed in this epoch.
-    repeated bytes slashed_public_keys = 6;
+    // 48 byte validator public keys that have been slashed in the given epoch.
+    repeated bytes slashed_public_keys = 6 [(gogoproto.moretags) = "ssz-size:\"?,48\""];
 
     // Indices of validators slashed in the given epoch.
     repeated uint64 slashed_indices = 7;
 
     // 48 byte validator public keys that have been involuntarily ejected in this epoch.
-    repeated bytes ejected_public_keys = 8;
+    repeated bytes ejected_public_keys = 8 [(gogoproto.moretags) = "ssz-size:\"?,48\""];
 
     // Indices of validators ejected in the given epoch.
     repeated uint64 ejected_indices = 9;
@@ -659,11 +658,11 @@ message ValidatorQueue {
 
     // Ordered list of 48 byte public keys awaiting activation. 0th index is the
     // next key to be processed.
-    repeated bytes activation_public_keys = 2;
+    repeated bytes activation_public_keys = 2 [(gogoproto.moretags) = "ssz-size:\"?,48\""];
 
     // Ordered list of public keys awaiting exit. 0th index is the next key to
     // be processed.
-    repeated bytes exit_public_keys = 3;
+    repeated bytes exit_public_keys = 3 [(gogoproto.moretags) = "ssz-size:\"?,48\""];
 }
 
 message ListValidatorAssignmentsRequest {
@@ -675,8 +674,7 @@ message ListValidatorAssignmentsRequest {
         bool genesis = 2;
     }
     // 48 byte validator public keys to filter assignments for the given epoch.
-    repeated bytes public_keys = 3;
-
+    repeated bytes public_keys = 3 [(gogoproto.moretags) = "ssz-size:\"?,48\""];
     // Validator indicies to filter assignments for the given epoch.
     repeated uint64 indices = 4;
 
@@ -710,7 +708,7 @@ message ValidatorAssignments {
         repeated uint64 proposer_slots = 4;
 
         // 48 byte BLS public key.
-        bytes public_key = 5;
+        bytes public_key = 5 [(gogoproto.moretags) = "ssz-size:\"48\""];
     }
 
     // The epoch for which this set of validator assignments is valid.

--- a/eth/v1alpha1/validator.proto
+++ b/eth/v1alpha1/validator.proto
@@ -15,6 +15,7 @@ syntax = "proto3";
 
 package ethereum.eth.v1alpha1;
 
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
 import "eth/v1alpha1/beacon_block.proto";
@@ -228,7 +229,7 @@ message DomainResponse {
 
 message ValidatorActivationRequest {
     // A list of 48 byte validator public keys.
-    repeated bytes public_keys = 1;
+    repeated bytes public_keys = 1 [(gogoproto.moretags) = "ssz-size:\"?,48\""];
 }
 
 message ValidatorActivationResponse {
@@ -264,7 +265,7 @@ message SyncedResponse {
 
 message ValidatorIndexRequest {
     // A 48 byte validator public key.
-    bytes public_key = 1;
+    bytes public_key = 1 [(gogoproto.moretags) = "ssz-size:\"48\""];
 }
 
 message ValidatorIndexResponse {
@@ -274,7 +275,7 @@ message ValidatorIndexResponse {
 
 message ValidatorStatusRequest {
     // A 48 byte validator public key.
-    bytes public_key = 1;
+    bytes public_key = 1 [(gogoproto.moretags) = "ssz-size:\"48\""];
 }
 
 enum ValidatorStatus {
@@ -312,7 +313,7 @@ message DutiesRequest {
     uint64 epoch = 1;
 
     // Array of byte encoded BLS public keys.
-    repeated bytes public_keys = 2;
+    repeated bytes public_keys = 2 [(gogoproto.moretags) = "ssz-size:\"?,48\""];
 }
 
 message DutiesResponse {
@@ -331,7 +332,7 @@ message DutiesResponse {
         repeated uint64 proposer_slots = 4;
 
         // 48 byte BLS public key for the validator who's assigned to perform a duty.
-        bytes public_key = 5;
+        bytes public_key = 5 [(gogoproto.moretags) = "ssz-size:\"48\""];
 
         // The current status of the validator assigned to perform the duty.
         ValidatorStatus status = 6;
@@ -346,15 +347,16 @@ message BlockRequest {
     uint64 slot = 1;
 
     // Validator's 32 byte randao reveal secret of the current epoch.
-    bytes randao_reveal = 2;
+    bytes randao_reveal = 2 [(gogoproto.moretags) = "ssz-size:\"48\""];
 
     // Validator's 32 byte graffiti message for the new block.
-    bytes graffiti = 3;
+    bytes graffiti = 3 [(gogoproto.moretags) = "ssz-size:\"32\""];
+
 }
 
 message ProposeResponse {
     // The block root of the successfully proposed beacon block.
-    bytes block_root = 1;
+    bytes block_root = 1 [(gogoproto.moretags) = "ssz-size:\"32\""];
 }
 
 message AttestationDataRequest {
@@ -367,7 +369,7 @@ message AttestationDataRequest {
 
 message AttestResponse {
     // The root of the attestation data successfully submitted to the beacon node.
-    bytes attestation_data_root = 1;
+    bytes attestation_data_root = 1 [(gogoproto.moretags) = "ssz-size:\"32\""];
 }
 
 message AggregateSelectionRequest {
@@ -376,10 +378,10 @@ message AggregateSelectionRequest {
     // Committee index of the validator at the given slot.
     uint64 committee_index = 2;
     // 48 byte public key of the validator.
-    bytes public_key = 3;
+    bytes public_key = 3 [(gogoproto.moretags) = "ssz-size:\"48\" spec-name:\"pubkey\""];
     // 96 byte signature of the validator on the slot. This is used as proof that the validator is
     // an aggregator for the given slot.
-    bytes slot_signature = 4;
+    bytes slot_signature = 4 [(gogoproto.moretags) = "ssz-size:\"96\""];
 }
 
 message AggregateSelectionResponse {
@@ -394,7 +396,7 @@ message SignedAggregateSubmitRequest {
 
 message SignedAggregateSubmitResponse {
     // The 32 byte hash tree root of the aggregated attestation data.
-    bytes attestation_data_root = 1;
+    bytes attestation_data_root = 1  [(gogoproto.moretags) = "ssz-size:\"32\""];
 }
 
 message CommitteeSubnetsSubscribeRequest {
@@ -412,10 +414,10 @@ message CommitteeSubnetsSubscribeRequest {
 // An Ethereum 2.0 validator.
 message Validator {
     // 48 byte BLS public key used for the validator's activities.
-    bytes public_key = 1;
+    bytes public_key = 1 [(gogoproto.moretags) = "ssz-size:\"48\" spec-name:\"pubkey\""];
 
     // 32 byte hash of the withdrawal destination public key.
-    bytes withdrawal_credentials = 2;
+    bytes withdrawal_credentials = 2 [(gogoproto.moretags) = "ssz-size:\"32\""];
 
     // The validators current effective balance in gwei.
     uint64 effective_balance = 3;

--- a/tools/ssz.bzl
+++ b/tools/ssz.bzl
@@ -1,0 +1,86 @@
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "GoLibrary",
+    "GoSource",
+)
+
+def _ssz_go_proto_library_impl(ctx):
+    if ctx.attr.go_proto != None:
+        go_proto = ctx.attr.go_proto
+        input_files = go_proto[OutputGroupInfo].go_generated_srcs.to_list()
+        package_path = input_files[0].dirname
+    elif hasattr(ctx.attr, "srcs") and len(ctx.attr.srcs) > 0:
+        package_path = ctx.attr.srcs[0].files.to_list()[0].dirname
+        input_files = ctx.attr.srcs[0].files.to_list()
+    else:
+        fail("Must have go_proto or srcs")
+
+    # Run the tool.
+    output = ctx.outputs.out
+    args = [
+        "--output=%s" % output.path,
+        "--path=%s" % package_path,
+    ]
+    if hasattr(ctx.attr, "includes") and len(ctx.attr.includes) > 0:
+        incs = []
+        for include in ctx.attr.includes:
+            incs.append(include[GoSource].srcs[0].dirname)
+            input_files += include[GoSource].srcs
+        args.append("--include=%s" % ",".join(incs))
+
+    if len(ctx.attr.objs) > 0:
+        args += ["--objs=%s" % ",".join(ctx.attr.objs)]
+
+    ctx.actions.run(
+        executable = ctx.executable.sszgen,
+        progress_message = "Generating ssz marshal and unmarshal functions",
+        inputs = input_files,
+        arguments = args,
+        outputs = [output],
+    )
+
+"""
+A rule that uses the generated pb.go files from a go_proto_library target to generate SSZ marshal
+and unmarshal functions as pointer receivers on the specified objects. To use this rule, provide a 
+go_proto_library target and specify the structs to generate methods in the "objs" field. Lastly, 
+include your new target as a source for the go_library that embeds the go_proto_library.
+
+Example:
+go_proto_library(
+  name = "example_go_proto",
+   ...
+) 
+
+ssz_gen_marshal(
+  name = "ssz_generated_sources",
+  go_proto = ":example_go_proto",
+  objs = [ # omit this field to generate for all structs in the package.
+    "AddressBook",
+    "Person",
+  ],
+)
+
+go_library(
+  name = "go_default_library",
+  srcs = [":ssz_generated_sources"],
+  embed = [":example_go_proto"],
+  deps = SSZ_DEPS,
+)
+"""
+ssz_gen_marshal = rule(
+    implementation = _ssz_go_proto_library_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "go_proto": attr.label(providers = [GoLibrary]),
+        "sszgen": attr.label(
+            default = Label("@com_github_ferranbt_fastssz//sszgen:sszgen"),
+            executable = True,
+            cfg = "host",
+        ),
+        "objs": attr.string_list(),
+        "includes": attr.label_list(providers = [GoLibrary]),
+    },
+    outputs = {"out": "generated.ssz.go"},
+)
+
+SSZ_DEPS = ["@com_github_ferranbt_fastssz//:go_default_library"]


### PR DESCRIPTION
Thanks to the feedback on https://github.com/prysmaticlabs/prysm/issues/5130, we realize it is not a big problem to include ssz tags by default for our protobufs in this repository. This PR amends the repo to include the necessary changes.