### PR TITLE
Asserts that gfind is available on OSX, for protobufs updates

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+function color() {
+    # Usage: color "31;5" "string"
+    # Some valid values for color:
+    # - 5 blink, 1 strong, 4 underlined
+    # - fg: 31 red,  32 green, 33 yellow, 34 blue, 35 purple, 36 cyan, 37 white
+    # - bg: 40 black, 41 red, 44 blue, 45 purple
+    printf '\033[%sm%s\033[0m\n' "$@"
+}
+
+system=""
+case "$OSTYPE" in
+darwin*) system="darwin" ;;
+linux*) system="linux" ;;
+msys*) system="windows" ;;
+cygwin*) system="windows" ;;
+*) exit 1 ;;
+esac
+readonly system
+
+findutil="find"
+# On OSX `find` is not GNU find compatible, so require "findutils" package.
+if [ "$system" == "darwin" ]; then
+    if [[ ! -x "/usr/local/bin/gfind" ]]; then
+        color 31 "Make sure that GNU 'findutils' package is installed: brew install findutils"
+        exit 1
+    else
+        findutil="gfind"
+    fi
+fi

--- a/scripts/update-go-pbs.sh
+++ b/scripts/update-go-pbs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+. $(dirname "$0")/common.sh
 
 # Script to copy pb.go files from bazel build folder to appropriate location.
 # Bazel builds to bazel-bin/... folder, script copies them back to original folder where .proto is.
@@ -8,36 +9,34 @@ bazel query 'kind(go_library, //...) union kind(go_proto_library, //...)' | xarg
 # Get locations of pb.go files.
 
 file_list=()
-while IFS= read -d $'\0' -r file ; do
+while IFS= read -d $'\0' -r file; do
     file_list=("${file_list[@]}" "$file")
-done < <(find -L $(bazel info bazel-bin)/eth -type f -regextype sed -regex ".*pb\.\(gw\.\)\?go$" -print0)
+done < <($findutil -L $(bazel info bazel-bin)/eth -type f -regextype sed -regex ".*pb\.\(gw\.\)\?go$" -print0)
 
 arraylength=${#file_list[@]}
 searchstring="/ethereumapis/"
 
 # Copy pb.go files from bazel-bin to original folder where .proto is.
-for (( i=0; i<${arraylength}; i++ ));
-do
-  destination=${file_list[i]#*$searchstring}
-  echo ${destination}
-  cp -R -L "${file_list[i]}" "$destination"
-  echo Updated $destination
+for ((i = 0; i < ${arraylength}; i++)); do
+    destination=${file_list[i]#*$searchstring}
+    color "34" $destination
+    cp -R -L "${file_list[i]}" "$destination"
+    echo Updated $destination
 done
 
-# Copy the generated.ssz.go file to live in the same package as 
+# Copy the generated.ssz.go file to live in the same package as
 # the generated protos.
 file_list=()
-while IFS= read -d $'\0' -r file ; do
+while IFS= read -d $'\0' -r file; do
     file_list=("${file_list[@]}" "$file")
-done < <(find -L $(bazel info bazel-bin)/eth -type f -name "*ssz.go" -print0)
+done < <($findutil -L $(bazel info bazel-bin)/eth -type f -name "*ssz.go" -print0)
 
 arraylength=${#file_list[@]}
 searchstring="/bin/"
 
-for (( i=0; i<${arraylength}; i++ ));
-do
-  destination=${file_list[i]#*$searchstring}
-  echo ${destination}
-  cp -R -L "${file_list[i]}" "$destination"
-  echo Updated $destination
+for ((i = 0; i < ${arraylength}; i++)); do
+    destination=${file_list[i]#*$searchstring}
+    color "34" $destination
+    cp -R -L "${file_list[i]}" "$destination"
+    echo Updated $destination
 done


### PR DESCRIPTION
On OSX, when no `gfind` util is installed, user will see:
![image](https://user-images.githubusercontent.com/188194/92271533-a7066f80-eef0-11ea-8987-7647432f2881.png)

After user installs `gfind`, protobufs updater script should work w/o any issues.


Closes #176 