### PR TITLE
Add beacon blocks API protos

### DIFF
--- a/eth/v1/beacon_blocks.proto
+++ b/eth/v1/beacon_blocks.proto
@@ -1,0 +1,210 @@
+// Copyright 2020 Prysmatic Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+package ethereum.eth.v1;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/any.proto";
+
+// Beacon chain API
+//
+// The beacon chain API can be used to access data relevant to the Ethereum 2.0
+// phase 0 beacon chain.
+service BeaconBlocks {
+  // Headers retrieves block headers matching given query. By default it will fetch current head slot blocks.
+  rpc Headers(BlockHeadersRequest) returns (BlockHeadersResponse) {
+    option (google.api.http) = { get: "/eth/v1/beacon/headers" };
+  }
+
+  // Header retrieves block header for given block id.
+  rpc Header(BlockRequest) returns (BlockHeaderResponse) {
+    option (google.api.http) = { get: "/eth/v1/beacon/headers/{block_id}" };
+  }
+
+  // Blocks instructs the beacon node to broadcast a newly signed beacon block to the beacon network, to be
+  // included in the beacon chain. The beacon node is not required to validate the signed BeaconBlock, and a successful
+  // response (20X) only indicates that the broadcast has been successful. The beacon node is expected to integrate the
+  // new block into its state, and therefore validate the block internally, however blocks which fail the validation are
+  // still broadcast but a different status code is returned (202).
+  rpc Blocks(BlockContainer) returns (google.protobuf.Empty) {
+    option (google.api.http) = { post: "/eth/v1/beacon/blocks" };
+  }
+
+  // Block retrieves block details for given block id.
+  rpc Block(BlockRequest) returns (BlockResponse) {
+    option (google.api.http) = { get: "/eth/v1/beacon/blocks/{block_id}" };
+  }
+
+  // Block retrieves hashTreeRoot of BeaconBlock/BeaconBlockHeader.
+  rpc BlockRoot(BlockRequest) returns (BlockRootResponse) {
+    option (google.api.http) = { get: "/eth/v1/beacon/blocks/{block_id}/root" };
+  }
+
+  // Block retrieves attestation included in requested block.
+  rpc BlockAttestations(BlockRequest) returns (BlockAttestationsResponse) {
+    option (google.api.http) = { get: "/eth/v1/beacon/blocks/{block_id}/attestations" };
+  }
+}
+
+message BlockHeadersRequest {
+  uint64 slot = 1;
+  string parent_root = 2;
+}
+
+message BlockHeadersResponse {
+  repeated BlockHeaderContainer data = 1;
+}
+
+message BlockRequest {
+  // The block identifier. Can be one of: "head" (canonical head in node's view), "genesis",
+  // "finalized", <slot>, <hex encoded blockRoot with 0x prefix>.
+  string block_id = 2;
+}
+
+message BlockHeaderResponse {
+  BlockHeaderContainer data = 1;
+}
+
+message BlockHeaderContainer {
+  string root = 1;
+  bool canonical = 2;
+  BlockHeaderMessage header = 3;
+}
+
+message BlockHeader {
+  BlockHeaderMessage message = 1;
+  string signature = 2;
+}
+
+message BlockHeaderMessage {
+  uint64 slot = 1;
+  uint64 proposer_index = 2;
+  string parent_root = 3;
+  string state_root = 4;
+  string body_root = 5;
+}
+
+message BlockResponse {
+  BlockContainer data = 1;
+}
+
+message BlockContainer {
+  Block message = 1;
+  string signature = 2;
+}
+
+message Block {
+  uint64 slot = 1;
+  uint64 proposer_index = 2;
+  string parent_root = 3;
+  string state_root = 4;
+  BlockBody body = 5;
+}
+
+message BlockBody {
+  string randao_reveal = 1;
+  Eth1Data eth1_data = 2;
+  string graffiti = 3;
+  repeated ProposerSlashing proposer_slashings = 4;
+  repeated AttesterSlashing attester_slashings = 5;
+  repeated Attestation attestations = 6;
+  repeated Deposit deposits = 7;
+  repeated VoluntaryExit voluntary_exits = 8;
+}
+
+message Eth1Data {
+  string deposit_root = 1;
+  uint64 deposit_count = 2;
+  string block_hash = 3;
+}
+
+message ProposerSlashing {
+  SignedBlockHeaderContainer signed_header_1 = 1;
+  SignedBlockHeaderContainer signed_header_2 = 2;
+}
+
+message SignedBlockHeaderContainer {
+  SignedBlockHeader message = 1;
+}
+
+message SignedBlockHeader {
+  uint64 slot = 1;
+  uint64 proposer_index = 2;
+  string parent_root = 3;
+  string state_root = 4;
+  string body_root = 5;
+  string signature = 6;
+}
+
+message AttesterSlashing {
+  IndexedAttestation attestation_1 = 1;
+  IndexedAttestation attestation_2 = 2;
+}
+
+message IndexedAttestation {
+  repeated uint64 attesting_indices = 1;
+  string signature = 2;
+  AttestationData data = 3;
+}
+
+message Attestation {
+  string aggregation_bits = 1;
+  string signature = 2;
+  AttestationData data = 3;
+  Checkpoint source = 4;
+  Checkpoint target = 5;
+}
+
+message AttestationData {
+  uint64 slot = 1;
+  uint64 index = 2;
+  string beacon_block_root = 3;
+  Checkpoint source = 4;
+  Checkpoint target = 5;
+}
+
+message Checkpoint {
+  uint64 epoch = 1;
+  string root = 2;
+}
+
+message Deposit {
+  repeated string proof = 1;
+  DepositData data = 2;
+}
+
+message DepositData {
+  string pubkey = 1;
+  string withdrawal_credentials = 2;
+  uint64 amount = 3;
+  string signature = 4;
+}
+
+message VoluntaryExit {
+  uint64 epoch = 1;
+  uint64 voluntary_exits = 2;
+}
+
+message BlockRootResponse {
+  BlockRootContainer data = 1;
+}
+
+message BlockRootContainer {
+  string root = 1;
+}
+
+message BlockAttestationsResponse {
+  repeated Attestation data = 1;
+}

--- a/eth/v1/beacon_state.proto
+++ b/eth/v1/beacon_state.proto
@@ -13,10 +13,8 @@
 // limitations under the License.
 syntax = "proto3";
 
-package ethereum.eth.v1alpha1;
+package ethereum.eth.v1;
 
-import "github.com/gogo/protobuf/gogoproto/gogo.proto";
-import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/any.proto";
 


### PR DESCRIPTION
This PR adds the following endpoint protos under `beacon_blocks.proto`

```
GET
​/eth​/v1​/beacon​/headers
Get block headers
GET
​/eth​/v1​/beacon​/headers​/{block_id}
Get block header
POST
​/eth​/v1​/beacon​/blocks
Publish a signed block.
GET
​/eth​/v1​/beacon​/blocks​/{block_id}
Get block
GET
​/eth​/v1​/beacon​/blocks​/{block_id}​/root
Get block root
GET
​/eth​/v1​/beacon​/blocks​/{block_id}​/attestations
Get block attestations
```