### PR TITLE
Add protos for ETH2 APIs config endpoints

### DIFF
--- a/eth/v1/config.proto
+++ b/eth/v1/config.proto
@@ -1,0 +1,61 @@
+// Copyright 2020 Prysmatic Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+package ethereum.eth.v1;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/any.proto";
+
+import "eth/v1/beacon_state.proto";
+
+// Config API
+//
+// The config API endpoints can be used to query chain configuration, specification, and fork schedules.
+service Config {
+  // ForkSchedule retrieve all scheduled upcoming forks this node is aware of.
+  rpc ForkSchedule(google.protobuf.Empty) returns (ForkScheduleResponse) {
+    option (google.api.http) = {get: "/eth/v1/config/fork_schedule"};
+  }
+
+  // Spec retrieves specification configuration (without Phase 1 params) used on this node. Specification params list
+  // Values are returned with following format:
+  // - any value starting with 0x in the spec is returned as a hex string
+  // - all other values are returned as number
+  rpc Spec(google.protobuf.Empty) returns (SpecResponse) {
+    option (google.api.http) = {get: "/eth/v1/config/spec"};
+  }
+
+  // DepositContract retrieves deposit contract address and genesis fork version.
+  rpc DepositContract(google.protobuf.Empty) returns (DepositContractResponse) {
+    option (google.api.http) = {get: "/eth/v1/config/deposit_contract"};
+  }
+}
+
+message ForkScheduleResponse {
+  Fork data = 1;
+}
+
+message SpecResponse {
+  map<string, string> data = 1;
+}
+
+message DepositContractResponse {
+  DepositContract data = 1;
+}
+
+message DepositContract {
+  uint64 chain_id = 1;
+  string address = 2;
+}


### PR DESCRIPTION
This PR adds the protos for the following endpoints:
```
GET
​/eth​/v1​/config​/fork_schedule
Get scheduled upcoming forks.
GET
​/eth​/v1​/config​/spec
Get spec params.
GET
​/eth​/v1​/config​/deposit_contract
Get deposit contract address.
```