### PR TITLE
Fix duplicated linked proto dependency

### DIFF
--- a/eth/v1alpha1/BUILD.bazel
+++ b/eth/v1alpha1/BUILD.bazel
@@ -104,8 +104,8 @@ go_proto_library(
         "@go_googleapis//google/api:annotations_go_proto",
         "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-swagger/options:options_go_proto",
         "@com_github_gogo_protobuf//gogoproto:go_default_library",
-	"@io_bazel_rules_go//proto/wkt:empty_go_proto",
-	"@com_github_golang_protobuf//descriptor:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:empty_go_proto",
+        "@com_github_golang_protobuf//descriptor:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
     ],
 )

--- a/eth/v1alpha1/BUILD.bazel
+++ b/eth/v1alpha1/BUILD.bazel
@@ -104,8 +104,8 @@ go_proto_library(
         "@go_googleapis//google/api:annotations_go_proto",
         "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-swagger/options:options_go_proto",
         "@com_github_gogo_protobuf//gogoproto:go_default_library",
-        "@com_github_golang_protobuf//descriptor:go_default_library",
-        "@com_github_golang_protobuf//ptypes/empty:go_default_library",
+	"@io_bazel_rules_go//proto/wkt:empty_go_proto",
+	"@com_github_golang_protobuf//descriptor:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
     ],
 )


### PR DESCRIPTION
For now, we must use the rules_go well known types to avoid issues in dependency resolution where the same package is linked more than once in a downstream repository. 