### PR TITLE
typo-Update http.proto

### DIFF
--- a/google/api/http.proto
+++ b/google/api/http.proto
@@ -33,7 +33,7 @@ message Http {
   // **NOTE:** All service configuration rules follow "last one wins" order.
   repeated HttpRule rules = 1;
 
-  // When set to true, URL path parmeters will be fully URI-decoded except in
+  // When set to true, URL path parameters will be fully URI-decoded except in
   // cases of single segment matches in reserved expansion, where "%2F" will be
   // left encoded.
   //


### PR DESCRIPTION
# Fix: Corrected typo in source file

## Changes
1. **File**: `google/api/http.proto`
   - Fixed a typo by changing "parmeters" to "parameters".

## Purpose
- Improved code accuracy by fixing the typographical error.
- Enhanced the clarity and professionalism of the codebase.
